### PR TITLE
[MOD] Use specific version for steuptools

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,13 +7,14 @@ formula_name = formula['name']
 
 driver:
   name: vagrant
-  hostname: freebsd.ci.local
+  hostname: letsencrypt.ci.local
 
 provisioner:
   name: salt_solo
-  salt_install: bootstrap
   salt_bootstrap_url: https://bootstrap.saltstack.com
-  salt_version: latest
+  salt_install: bootstrap
+  salt_bootstrap_options: -X git v2017.7.5
+  salt_version: '2017.7.5'
   pillars-from-files:
     <%= formula_name %>.sls: pillar.example/test.sls
   pillars:

--- a/letsencrypt/packages.sls
+++ b/letsencrypt/packages.sls
@@ -31,7 +31,7 @@ letsencrypt_packages_virtualenv_/opt/letsencrypt:
 # Install latest version of setuptools, pip install letsencrypt might fail otherwise
 letsencrypt_packages_pip-setuptools:
   pip.installed:
-    - name: setuptools
+    - name: setuptools==38.7.0
     - upgrade: True
     - ignore_installed: True
     - bin_env: /opt/letsencrypt


### PR DESCRIPTION
This is a workaround to prevent UnicodeError in salt pip.installed state. Looks like this is only present when installing latest version fo setuptools