### PR TITLE
Update packages.sls

### DIFF
--- a/letsencrypt/packages.sls
+++ b/letsencrypt/packages.sls
@@ -3,7 +3,7 @@
 letsencrypt_packages:
   pkg.installed:
     - pkgs:
-      - py27-pip
+      - py36-pip
 {% elif salt['grains.get']('os_family') == 'Debian' %}
 letsencrypt_packages:
   pkg.installed:


### PR DESCRIPTION
Python 3 is now the default version in FreeBSD 11.x