### PR TITLE
use python3

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -30,7 +30,7 @@ provisioner:
         - <%= formula_name %>
 
 platforms:
-  - name: freebsd-11.2
+  - name: freebsd-11.3
     driver:
       cache_directory: false
 

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -13,7 +13,7 @@ provisioner:
   name: salt_solo
   salt_bootstrap_url: https://bootstrap.saltstack.com
   salt_install: bootstrap
-  salt_bootstrap_options: -X git v2019.2.0
+  salt_bootstrap_options: -x python3 git v2019.2.0
   salt_version: '2019.2.0'
   pillars-from-files:
     <%= formula_name %>.sls: pillar.example/test.sls

--- a/letsencrypt/packages.sls
+++ b/letsencrypt/packages.sls
@@ -5,24 +5,32 @@ letsencrypt_packages:
     - pkgs:
       - py27-pip
       - py36-pip
-{% elif salt['grains.get']('os_family') == 'Debian' %}
-letsencrypt_packages:
-  pkg.installed:
-    - pkgs:
-      - libffi-dev
-      - python-dev
-      # We need python-pip to be able to use to pip.installed saltstack state module
-      - python-pip
-      # We need lsof to solve the chicken-egg problem when requesting the first certificate when there is no webserver yet
-      - lsof
-      # We need this package to install the pip package "certbot"
-      - libssl-dev
-{% endif %}
 
 # Install virtualenv
 letsencrypt_packages_pip_virtualenv:
   pip.installed:
     - name: virtualenv
+    - bin_env: '/usr/local/bin/pip-3.6'
+    - require:
+      - pkg: letsencrypt_packages
+{% elif salt['grains.get']('os_family') == 'Debian' %}
+letsencrypt_packages:
+  pkg.installed:
+    - pkgs:
+      - libffi-dev
+      - python3-dev
+      # We need python3-pip to be able to use to pip.installed saltstack state module
+      - python3-pip
+      # We need lsof to solve the chicken-egg problem when requesting the first certificate when there is no webserver yet
+      - lsof
+      # We need this package to install the pip package "certbot"
+      - libssl-dev
+
+# Install virtualenv
+letsencrypt_packages_pip_virtualenv:
+  pip.installed:
+    - name: virtualenv
+{% endif %}
 
 # Create a virtualenv for letsencrypt
 letsencrypt_packages_virtualenv_/opt/letsencrypt:

--- a/test/integration/default/serverspec/letsencrypt_spec.rb
+++ b/test/integration/default/serverspec/letsencrypt_spec.rb
@@ -5,23 +5,38 @@ set :backend, :exec
 if os[:family] == 'freebsd'
   pip_package = "py27-pip"
   group       = "wheel"
+
+  describe 'letsencrypt' do
+    it "pip is installed" do
+      expect(package(pip_package)).to be_installed
+    end
+
+    it "virtualenv is installed" do
+      expect(command("pip-3.6 show virtualenv").exit_status).to eql(0)
+    end
+
+    it "setuptools is installed" do
+      expect(command("pip-3.6 show setuptools").exit_status).to eql(0)
+    end
+  end
 elsif ['debian', 'ubuntu'].include?(os[:family])
-  pip_package = "python-pip"
+  pip_package = "python3-pip"
   group      = "root"
+
+  describe 'letsencrypt' do
+    it "pip is installed" do
+      expect(package(pip_package)).to be_installed
+    end
+
+    it "virtualenv is installed" do
+      expect(command("pip3 show virtualenv").exit_status).to eql(0)
+    end
+
+    it "setuptools is installed" do
+      expect(command("pip3 show setuptools").exit_status).to eql(0)
+    end
+  end
 end
-
-describe 'letsencrypt' do
-  it "pip is installed" do
-    expect(package(pip_package)).to be_installed
-  end
-
-  it "virtualenv is installed" do
-    expect(command("pip show virtualenv").exit_status).to eql(0)
-  end
-
-  it "setuptools is installed" do
-    expect(command("pip show setuptools").exit_status).to eql(0)
-  end
 
   describe file('/opt/letsencrypt') do
     it { should be_directory }
@@ -40,4 +55,3 @@ describe 'letsencrypt' do
   describe cron do
     it { should have_entry('1 0 1 */2 * /etc/letsencrypt/saltstack/cronjobs/something.test.com.sh > /dev/null 2>&1').with_user('root') }
   end
-end


### PR DESCRIPTION
sets python3 for bootstrap-salt.sh on .kitchen.yml:

```
provisioner:
  name: salt_solo
  salt_bootstrap_options: -x python3
```

Salt python3 on FreeBSD is not yet supported. Keeping python2 for pip_state: 
https://github.com/saltstack/salt-bootstrap#python-3-support

Tested on platforms:
  - name: freebsd-12.0
    driver:
      cache_directory: false

  - name: freebsd-11.2
    driver:
      cache_directory: false

  - name: ubuntu-16.04
    driver:
      box: ubuntu/xenial64

  - name: ubuntu-18.04
    driver:
      box: ubuntu/bionic64